### PR TITLE
section ajout variable env fichier service systemd

### DIFF
--- a/_posts/2020-10-19-demarrer-couchdb3-sans-mot-de-passe-admin.markdown
+++ b/_posts/2020-10-19-demarrer-couchdb3-sans-mot-de-passe-admin.markdown
@@ -27,3 +27,21 @@ Redémarrer le service couchdb
 ```
 service couchdb restart
 ```
+
+## Méthode alternative : systemD
+
+Une autre solution consiste à exporter la variable d'environnement dans le fichier du service systemD. La *bonne pratique actuelle* est de créer un fichier *override.conf*.
+
+```
+systemctl edit couchdb
+```
+
+Cela va créer un répertoire */etc/systemd/system/couchdb.service.d/* pour y stocker le fichier *override.conf* et sera lu automagiquement. Cela permet d'avoir un fichier central qui permet d'altérer ou d'ajouter de la configuration fournie par la distribution, persistante à une montée de version ou de changement de configuration de la distribution.
+
+
+Il suffit donc d'ajouter les lignes suivantes pour ajouter la variable d'environnement :
+
+```
+[Service]
+Environment="COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1"
+```


### PR DESCRIPTION
Pour ne pas avoir d'utilisateur admin dans couchdb